### PR TITLE
Fixes motivated by T.L Hulsey's critique, and related elaborations

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -97,8 +97,10 @@ shall reserve all rights to seek repairs.
 
 ## Republican and transparent government
 
-Cities shall recognize the popular sovereignty
-of each of its Citizens.
+Cities shall recognize
+the individual sovereignty of all people over themselves
+and the popular sovereignty of its Citizens
+over the land it stewards.
 
 The administration of a City's powers and duties
 shall be carried out only by officers

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -198,7 +198,7 @@ adjacent and surrounding areas
 but have been typically found not to
 warrant criminal charges nor civil restitution.
 
-Cities shall have the natural authority to restrict and regulate
+Cities shall maintain the inherent authority to restrict and regulate
 activities conducted on the commons they provide.
 
 ## Collection of natural rent

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -160,6 +160,13 @@ against parties wishing to
 make exclusive use of such natural opportunities
 and willing to pay its rent.
 
+The collection of rent on a City's lands
+shall not be made to construe
+a notion of a City's ownership over the land.
+Instead, the City shall be understood to be
+only the steward of its lands
+for the benefit of its Citizen's.
+
 ## Power to spend
 
 Cities may allocate,
@@ -171,7 +178,7 @@ and to provide for the commons, common services, and common infrastructure.
 For the purposes of accounting
 and allowing for the fair competition of alternative uses,
 Cities shall fairly compete for,
-and pay the appropriate rent for,
+and pay the prevailing ground rent for,
 all land and natural opportunities
 they wish to allocate to such common purposes.
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -467,13 +467,13 @@ the highest office in the Ministry of the Treasury,
 and shall be elected by an approval vote of the Citizens
 and confirmed by a 1st-order plurality vote of the Council of Cities.
 
-### Collection of rent
+### Collection of rent allocated to the League
 
 The Ministry of the Treasury shall,
 subject to a Directive of the Councils,
-collect annually a proportion of the rent collected by each City.
+collect annually a proportion of the ground rent collected by each City.
 Such proportion shall be equal amongst the Cities
-and a Directive only specifying this proportion shall pass
+and a Directive specifying only this proportion shall pass
 with a 2nd-order plurality vote of the Council of Citizens
 and a 1st-order plurality vote of the Council of Cities.
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -304,12 +304,13 @@ a particular plurality of the rendered votes in favor
 to pass the motion in question.
 These pluralities are defined by an ordinal number
 corresponding to the ratio required to pass.
-A 1st-order plurality shall refer to a ratio of at least
-$1 - \frac{1 + \sqrt{5}}{2}^{-1}$,
-a 2nd-order plurality shall refer to a ratio of at least
-$1 - \frac{1 + \sqrt{5}}{2}^{-2}$,
-and a 3rd-order plurality shall refer to a ratio of at least
-$1 - \frac{1 + \sqrt{5}}{2}^{-3}$.
+Provided the golden ratio $\phi = \frac{1 + \sqrt{5}}{2}$
+A 1st-order plurality shall indicate
+a ratio of at least $1 - \phi^{-1} \approx 38.2%$,
+a 2nd-order plurality shall indicate
+a ratio of at least $1 - \phi^{-2} \approx 61.8%$,
+and a 3rd-order plurality shall indicate
+a ratio of at least $1 - \phi^{-3} \approx 76.4%$.
 
 ## Directives
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -49,10 +49,16 @@ to adequately defend themselves from transgressions,
 or enlist an agent to so on their behalf,
 and to seek appropriate remunerative or punitive damages
 for those which are committed.
+As such, a person transgressing
+against the natural rights of another
+may forfeit their rights
+as indicated for the exercise of self-defense
+or necessary the post-facto application of justice.
 
 ## Rights of the accused
 
-Any person accused of transgressing against the rights of another
+Any person accused of transgressing
+against the natural rights of another
 shall be presumed innocent until and unless proven guilty
 beyond a reasonable doubt
 by a jury of their citizen peers

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -396,7 +396,8 @@ establish embargoes on foreign states,
 and command all national armed forces
 for the defense of the parties of the League.
 
-The President shall have the duty and power
+Provided resources allocated by the Councils,
+the President shall have the duty and power
 to establish the forces, armed and unarmed,
 necessary for the execution of these responsibilities.
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -282,12 +282,12 @@ one or more forums
 and restrict participation in each of those forums
 to Citizens having a minimum number of delegated votes.
 
-## Election of the Council of Cities
+## Representation in the Council of Cities
 
-Each City shall select one representative
+Each City shall appoint one representative
 to the Council of Cities.
 
-The process by which a City selects its representative
+The process by which a City appoints its representative
 shall be the prerogative of each City,
 provided such process be consistent with the principles of republicanism.
 However, such process shall be documented, made public,

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -18,6 +18,8 @@ The League shall acknowledge and affirm
 all inherent natural rights
 belonging to each and every individual.
 
+### Principle of equal treatment under the law
+
 All persons,
 regardless of place of origin,
 opinions or religious beliefs held publicly or privately,
@@ -25,6 +27,8 @@ or arbitrary physical attribute,
 shall be treated equally,
 with dignity and respect,
 under the law.
+
+### Principle of self-ownership and equal opportunity
 
 All persons are the owners over their entire person
 and the products of their labors.
@@ -37,6 +41,8 @@ which neither threatens or commits violence against, nor defrauds another.
 All persons have an equal natural right
 to move about the earth,
 and to make use of the natural opportunities which it provides.
+
+### Principle of self-defense and restitution
 
 All persons have the inherent and natural right
 to adequately defend themselves from transgressions,
@@ -65,7 +71,7 @@ which offends a reasonable sense of justice.
 
 # II: Cities
 
-## Naturalization of Cities
+## Accession of Cities to the League
 
 No City,
 having demonstrated the capacity and willingness
@@ -95,6 +101,48 @@ to any party in the League;
 and the League and its constituents
 shall reserve all rights to seek repairs.
 
+## Naturalization of Citizens to Cities
+
+Cities shall provide for the naturalization of their Citizens
+without discriminating in any way contradictory to
+the principle of equal treatment under the law.
+
+Cities may require a minimum age for naturalization,
+but such requirement shall be no greater than 20 years of age.
+
+Cities may require for naturalization
+residency within the City for a minimum period,
+but must not require more than 7 years of continuous residency.
+
+Cities may require for naturalization
+a demonstration of civic competence,
+but must provide a limited exemption
+for persons with cognitive or physical impairments.
+
+Cities may require for naturalization
+a commitment to periodically serve as a juror
+in its courts or the courts it regulates,
+though such commitment shall be waived
+for those exempted from civic competence,
+and Cities may provide an optional exemption
+which waives this commitment
+by forgoing all or part of the Citizen's dividend.
+
+Cities shall provide titular citizenship
+for the children of its Citizens
+and minors meeting the City's residency requirement,
+which confers no obligations nor privileges
+excepting the privilege of passport.
+Cities may annul titular Citizenship
+for those more senior than a prescribed age,
+which shall be no less than 1 year more than
+the minimum age to attain full Citizenship,
+and who have not yet elected to attain full Citizenship.
+
+Cities shall not compel citizenship for its residents,
+and Citizens shall be naturalized
+only by their own volition, with soundness of mind.
+
 ## Republican and transparent government
 
 Cities shall recognize
@@ -106,7 +154,9 @@ The administration of a City's powers and duties
 shall be carried out only by officers
 chosen, directly or indirectly, by the Citizens of the City.
 Cities must provide equal opportunity for suffrage
-to all of its Citizens.
+to all of its Citizens,
+excepting those exempted from
+demonstrating civic competence or jury service.
 
 All bodies and processes comprising a City's government,
 inclusive of its executive and administrative offices,
@@ -119,10 +169,6 @@ by the Ministry of Accountability.
 
 Cities shall have the duty to establish or regulate
 courts which uphold the rights of accused persons.
-
-Cities shall have the authority to compel its Citizens
-to periodically serve on the juries of
-its courts, or the courts which it regulates.
 
 ## Militias
 
@@ -191,6 +237,12 @@ not otherwise allocated by the City's most representative house,
 nor allocated to the League,
 shall be returned in equal shares to its Citizens.
 
+Cities may except non-resident Citizens
+from being party to the dividend,
+but only after a grace period
+no less than the duration of
+the minimum residency requirement for naturalization.
+
 ## Establishment of money
 
 Cities may coin and regulate or choose the money
@@ -217,7 +269,7 @@ thereby subverting the status of the League as a nation.
 
 # III: Citizens
 
-## Naturalization
+## Naturalization to the League
 
 No person,
 having met the requirements set forth in this Constitution,
@@ -230,9 +282,6 @@ renouncing their Citizenship with the League at any time.
 All Citizens must be of no less than the age of 16.
 
 All Citizens must pass a constitutional competence examination
-unless excused on account of incapacity.
-
-All Citizens must be in good standing as a juror
 unless excused on account of incapacity.
 
 All Citizens must be Citizens of a City in the League
@@ -256,7 +305,6 @@ and otherwise unallocated by the Councils.
 
 All Citizens shall have suffrage within the League
 excepting those excused from constitutional competence
-or their duty as a juror
 on account of incapacity.
 
 # IV: Councils of the League
@@ -441,9 +489,10 @@ and confirmed by a 1st-order plurality vote of the Council of Cities.
 The Ministry of Civic Affairs shall,
 subject to the provisions of this Constitution
 and the Directives of the Councils,
-administer the naturalization of Cities and Citizens
+administer the accession of Cities to the League and
+the naturalization of Citizens to the League,
 and issue passports and other legal documentation
-declaring the state of its constituents as necessary.
+declaring the status of its constituents as necessary.
 
 ### Conduct of elections
 


### PR DESCRIPTION
### :scroll: Fix wording for authority to regulate activity within commons

### :scroll: Make explicit the forfeit of rights for transgressing

### :scroll: Elaborate the concept of City Citizenship
The original motivation was to clarify
that jury service is not unilaterally compeled
but an allowable contingency for citizenship within a City.
This highlighted a major missing element,
which is the requirements and restrictions
for Cities to provide citizenship to its residents.

### :scroll: Improve language over individual/popular sovereignty

### :scroll: Clarify language around rent allocated to League purposes

### :scroll: Clarify presidential power comes from Council-allocated resources

### :scroll: Factor out phi (golden ratio) from plurality definitions

### :scroll: Cities 'appoint' vs 'select' councilmembers

### :scroll: Slightly improve wording for City relationship to using land